### PR TITLE
chore: minor updates to docs, build config as part of release v0.2.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Salesforce Accessibility Automated Testing Libraries and Tools (@sa11y packages).
 
-[![Build](https://circleci.com/gh/salesforce/sa11y.svg?style=svg&circle-token=0e28763afb8e2d0f1293f08a112e8b5e387b324a)](https://app.circleci.com/pipelines/github/salesforce/sa11y?branch=master)
+[![Build](https://circleci.com/gh/salesforce/sa11y.svg?style=svg)](https://app.circleci.com/pipelines/github/salesforce/sa11y?branch=master)
 
 <!-- Temp disabling code cov badge due to https://github.com/salesforce/sa11y/issues/14
      Re-enable with a code cov service that works with CircleCi -->

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -8,7 +8,8 @@
 module.exports = {
     '**/*.{js,ts,json,yaml,yml,md}': 'prettier --write',
     '**/*.{js,ts,md}': ['eslint --fix', 'cspell -- --no-summary'],
-    '**/*.md': ['markdown-link-check --quiet --config mdLinkChecker.json', 'doctoc --github'],
+    '**/*.md': ['markdown-link-check --quiet', 'doctoc --github'],
     'yarn.lock': 'yarn lint:lockfile',
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
     'package.json': () => 'yarn install',
 };

--- a/mdLinkChecker.json
+++ b/mdLinkChecker.json
@@ -1,8 +1,0 @@
-{
-    "ignorePatterns": [
-        {
-            "TODO": "REMOVE after repository is made public",
-            "pattern": "^https://github.com/salesforce/sa11y"
-        }
-    ]
-}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "release:changelog": "conventional-changelog --infile CHANGELOG.md --same-file --preset angular --output-unreleased",
         "release:version": "yarn lerna version --no-push --no-git-tag-version",
         "release:version:auto": "yarn release:version --conventional-commits --no-changelog",
-        "release:publish": "yarn lerna publish from-package",
+        "release:publish": "yarn test:clean && yarn lerna publish from-package",
         "test": "jest --coverage",
         "test:ci": "yarn lint:all && yarn test --ci && yarn test:wdio",
         "test:clean": "yarn build:clean && yarn test:ci",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.3-beta.0",
     "description": "Provides assertAccessible API to check DOM for accessibility issues",
     "license": "BSD-3-Clause",
-    "homepage": "https://github.com/salesforce/sa11y/blob/master/packages/assert#readme",
+    "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/assert#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/salesforce/sa11y.git",
@@ -27,5 +27,8 @@
     },
     "devDependencies": {
         "@sa11y/test-utils": "0.2.0-beta.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,5 +16,8 @@
     ],
     "dependencies": {
         "axe-core": "3.5.5"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -3,7 +3,7 @@
     "version": "0.2.1-beta.0",
     "description": "Accessibility results re-formatter",
     "license": "BSD-3-Clause",
-    "homepage": "https://github.com/salesforce/sa11y/blob/master/packages/format#readme",
+    "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/format#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/salesforce/sa11y.git",
@@ -27,5 +27,8 @@
     },
     "devDependencies": {
         "@sa11y/test-utils": "0.2.0-beta.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/jest/__tests__/__snapshots__/setup.test.ts.snap
+++ b/packages/jest/__tests__/__snapshots__/setup.test.ts.snap
@@ -3,5 +3,5 @@
 exports[`jest setup should throw error when global expect is undefined 1`] = `
 "Unable to find Jest's global expect.
 Please check you have added @sa11y/jest correctly to your jest configuration.
-See https://github.com/salesforce/sa11y/blob/master/packages/jest/README.md for help."
+See https://github.com/salesforce/sa11y/tree/master/packages/jest#readme for help."
 `;

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.3-beta.0",
     "description": "Accessibility testing matcher for Jest",
     "license": "BSD-3-Clause",
-    "homepage": "https://github.com/salesforce/sa11y/blob/master/packages/jest#readme",
+    "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/jest#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/salesforce/sa11y.git",
@@ -33,5 +33,8 @@
     "devDependencies": {
         "@sa11y/common": "0.2.0-beta.0",
         "@sa11y/test-utils": "0.2.0-beta.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/jest/src/setup.ts
+++ b/packages/jest/src/setup.ts
@@ -22,7 +22,7 @@ export function registerSa11yMatcher(): void {
         throw new Error(
             "Unable to find Jest's global expect." +
                 '\nPlease check you have added @sa11y/jest correctly to your jest configuration.' +
-                '\nSee https://github.com/salesforce/sa11y/blob/master/packages/jest/README.md for help.'
+                '\nSee https://github.com/salesforce/sa11y/tree/master/packages/jest#readme for help.'
         );
     }
 }

--- a/packages/preset-rules/package.json
+++ b/packages/preset-rules/package.json
@@ -3,7 +3,7 @@
     "version": "0.2.0-beta.0",
     "description": "Accessibility preset rule configs for axe",
     "license": "BSD-3-Clause",
-    "homepage": "https://github.com/salesforce/sa11y/blob/master/packages/preset-rules#readme",
+    "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/preset-rules#readme",
     "repository": {
         "type": "git",
         "url": "https://github.com/salesforce/sa11y.git",
@@ -21,5 +21,8 @@
     ],
     "dependencies": {
         "axe-core": "3.5.5"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/test-integration/package.json
+++ b/packages/test-integration/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/test-integ#readme",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/salesforce/sa11y.git",
+        "url": "https://github.com/salesforce/sa11y.git",
         "directory": "packages/test-integration"
     },
     "devDependencies": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,7 +7,7 @@
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/test-utils#readme",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/salesforce/sa11y.git",
+        "url": "https://github.com/salesforce/sa11y.git",
         "directory": "packages/test-utils"
     },
     "main": "dist/index.js",

--- a/packages/wdio/package.json
+++ b/packages/wdio/package.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/wdio#readme",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/salesforce/sa11y.git",
+        "url": "https://github.com/salesforce/sa11y.git",
         "directory": "packages/wdio"
     },
     "keywords": [
@@ -35,5 +35,8 @@
     },
     "devDependencies": {
         "@sa11y/test-utils": "0.2.0-beta.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }


### PR DESCRIPTION
Minor changes to docs, config performed as part of 
* [the latest release to npm](https://github.com/salesforce/sa11y/releases/tag/v0.2.0-beta)
  - build: add public access publish config to all public pkgs for lerna
  - build: add build, test to release publish npm script
  - docs: fix homepage and url fields for uniformity across packages
* making the repo public
  - docs: remove obsolete CI token now that the repo is public
  - test(markdown-link-check): remove obsolete config


