### PR TITLE
chore: include .d.ts files in package.json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased (2021-01-21)
+
+### Features
+
+-   **typescript:** include d.ts TypeScript definitions in packages
+
 # Changelog
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -17,7 +17,8 @@
     "main": "dist/assert.js",
     "types": "dist/assert.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "dependencies": {
         "@sa11y/common": "0.2.3-beta.0",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,7 +12,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "dependencies": {
         "axe-core": "4.1.1"

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -20,7 +20,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "dependencies": {
         "axe-core": "4.1.1"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -19,7 +19,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "dependencies": {
         "@sa11y/assert": "0.2.0-beta.0",

--- a/packages/preset-rules/package.json
+++ b/packages/preset-rules/package.json
@@ -17,7 +17,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "dependencies": {
         "axe-core": "4.1.1"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -13,7 +13,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "dependencies": {
         "@sa11y/common": "0.2.3-beta.0"

--- a/packages/wdio/package.json
+++ b/packages/wdio/package.json
@@ -20,7 +20,8 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "files": [
-        "dist/**/*.js"
+        "dist/**/*.js",
+        "dist/**/*.d.ts"
     ],
     "scripts": {
         "test": "wdio run ../../wdio.conf.js",


### PR DESCRIPTION
This enables TypeScript code importing sa11y packages to recognize sa11y's types and then typecheck.