### PR TITLE
chore: move to unified versioning for all @sa11y pkgs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+-   [3.0.0 (2021-09-16)](#300-2021-09-16)
 -   [0.11.2-beta (2021-09-13)](#0112-beta-2021-09-13)
     -   [WDIO](#wdio)
 -   [0.11.1-beta (2021-09-10)](#0111-beta-2021-09-10)
@@ -59,6 +60,11 @@
     -   [Features](#features-14)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# [3.0.0](https://github.com/salesforce/sa11y/releases/tag/v3.0.0) (2021-09-16)
+
+-   Moving to unified versioning of @sa11y packages instead of independent versioning for reducing complexity of managing independent versions
+-   No code changes, No breaking changes
 
 # [0.11.2-beta](https://github.com/salesforce/sa11y/releases/tag/v0.11.2-beta) (2021-09-13)
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "packages": ["packages/*"],
-    "version": "independent",
+    "version": "3.0.0",
     "exact": true,
     "npmClient": "yarn",
     "useWorkspaces": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "name": "sa11y-monorepo",
-    "version": "0.11.2-beta",
     "private": true,
     "description": "Salesforce Accessibility Automated Testing Libraries and Tools (@sa11y packages)",
     "license": "BSD-3-Clause",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/assert",
-    "version": "1.0.0",
+    "version": "3.0.0",
     "description": "Provides assertAccessible API to check DOM for accessibility issues",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/assert#readme",
@@ -21,13 +21,13 @@
         "dist/**/*.d.ts*"
     ],
     "dependencies": {
-        "@sa11y/common": "0.4.0",
-        "@sa11y/format": "0.5.0",
-        "@sa11y/preset-rules": "1.0.1",
+        "@sa11y/common": "3.0.0",
+        "@sa11y/format": "3.0.0",
+        "@sa11y/preset-rules": "3.0.0",
         "axe-core": "4.3.3"
     },
     "devDependencies": {
-        "@sa11y/test-utils": "0.4.3"
+        "@sa11y/test-utils": "3.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/browser-lib/package.json
+++ b/packages/browser-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/browser-lib",
-    "version": "1.0.1",
+    "version": "3.0.0",
     "description": "Provides a minified version of selected `@sa11y` libraries to be injected into a browser (using webdriver) and executed from integration testing workflows.",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/browser-lib#readme",
@@ -34,16 +34,16 @@
         "url": "https://github.com/salesforce/sa11y/issues"
     },
     "dependencies": {
-        "@sa11y/format": "0.5.0",
-        "@sa11y/preset-rules": "1.0.1",
+        "@sa11y/format": "3.0.0",
+        "@sa11y/preset-rules": "3.0.0",
         "axe-core": "4.3.3"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "20.0.0",
         "@rollup/plugin-node-resolve": "13.0.4",
         "@rollup/plugin-replace": "3.0.0",
-        "@sa11y/common": "0.4.0",
-        "@sa11y/test-utils": "0.4.3",
+        "@sa11y/common": "3.0.0",
+        "@sa11y/test-utils": "3.0.0",
         "rollup": "2.56.3",
         "rollup-plugin-polyfill-node": "0.7.0",
         "rollup-plugin-progress": "1.1.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/common",
-    "version": "0.4.0",
+    "version": "3.0.0",
     "description": "Common utilities, constants, error messages for @sa11y",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/common#readme",

--- a/packages/format/package.json
+++ b/packages/format/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/format",
-    "version": "0.5.0",
+    "version": "3.0.0",
     "description": "Accessibility results re-formatter",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/format#readme",
@@ -24,12 +24,12 @@
         "dist/**/*.d.ts*"
     ],
     "dependencies": {
-        "@sa11y/preset-rules": "1.0.1",
+        "@sa11y/preset-rules": "3.0.0",
         "axe-core": "4.3.3"
     },
     "devDependencies": {
-        "@sa11y/common": "0.4.0",
-        "@sa11y/test-utils": "0.4.3"
+        "@sa11y/common": "3.0.0",
+        "@sa11y/test-utils": "3.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/jest",
-    "version": "1.1.0",
+    "version": "3.0.0",
     "description": "Accessibility testing matcher for Jest",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/jest#readme",
@@ -24,17 +24,17 @@
     ],
     "dependencies": {
         "@jest/test-result": "26.6.2",
-        "@sa11y/assert": "1.0.0",
-        "@sa11y/format": "0.5.0",
-        "@sa11y/preset-rules": "1.0.1",
+        "@sa11y/assert": "3.0.0",
+        "@sa11y/format": "3.0.0",
+        "@sa11y/preset-rules": "3.0.0",
         "jest-matcher-utils": "26.6.2"
     },
     "peerDependencies": {
         "jest": ">=26.0.0"
     },
     "devDependencies": {
-        "@sa11y/common": "0.4.0",
-        "@sa11y/test-utils": "0.4.3"
+        "@sa11y/common": "3.0.0",
+        "@sa11y/test-utils": "3.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/preset-rules/package.json
+++ b/packages/preset-rules/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/preset-rules",
-    "version": "1.0.1",
+    "version": "3.0.0",
     "description": "Accessibility preset rule configs for axe",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/preset-rules#readme",
@@ -21,7 +21,7 @@
         "dist/**/*.d.ts*"
     ],
     "devDependencies": {
-        "@sa11y/common": "0.4.0",
+        "@sa11y/common": "3.0.0",
         "axe-core": "4.3.3",
         "markdown-table-ts": "1.0.3"
     },

--- a/packages/test-integration/package.json
+++ b/packages/test-integration/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/test-integration",
-    "version": "0.2.4",
+    "version": "3.0.0",
     "private": true,
     "description": "Private package for integration testing @sa11y packages",
     "license": "BSD-3-Clause",
@@ -11,8 +11,8 @@
         "directory": "packages/test-integration"
     },
     "devDependencies": {
-        "@sa11y/jest": "1.1.0",
-        "@sa11y/test-utils": "0.4.3",
-        "@sa11y/wdio": "2.0.2-beta.0"
+        "@sa11y/jest": "3.0.0",
+        "@sa11y/test-utils": "3.0.0",
+        "@sa11y/wdio": "3.0.0"
     }
 }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/test-utils",
-    "version": "0.4.3",
+    "version": "3.0.0",
     "private": true,
     "description": "Private package providing test utilities for @sa11y packages",
     "license": "BSD-3-Clause",
@@ -17,6 +17,6 @@
         "dist/**/*.d.ts*"
     ],
     "dependencies": {
-        "@sa11y/common": "0.4.0"
+        "@sa11y/common": "3.0.0"
     }
 }

--- a/packages/wdio/package.json
+++ b/packages/wdio/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sa11y/wdio",
-    "version": "2.0.2-beta.0",
+    "version": "3.0.0",
     "description": "Accessibility testing API for WebdriverIO",
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/salesforce/sa11y/tree/master/packages/wdio#readme",
@@ -29,16 +29,16 @@
         "test:watch": "yarn test --watch"
     },
     "dependencies": {
-        "@sa11y/common": "0.4.0",
-        "@sa11y/format": "0.5.0",
-        "@sa11y/preset-rules": "1.0.1",
+        "@sa11y/common": "3.0.0",
+        "@sa11y/format": "3.0.0",
+        "@sa11y/preset-rules": "3.0.0",
         "axe-core": "4.3.3"
     },
     "peerDependencies": {
         "webdriverio": ">=6.0.0"
     },
     "devDependencies": {
-        "@sa11y/test-utils": "0.4.3"
+        "@sa11y/test-utils": "3.0.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
## Chore 🧹 
* **No code changes, No breaking changes** - just moving to unified versioning of @sa11y packages instead of independent versioning to reduce complexity of managing independent versions

### Why 
* Due to the complexity of independently versioning the @sa11y packages, some packages were missed from version bumps in #74
* Based on the experience of managing the versions of the @sa11y packages independently so far the overhead of independent versioning doesn't make much sense especially for @sa11y since most packages are not really independent from each other as much as I initially thought.
* Switching to unified versioning going forward .. 
  * Given that the highest version among @sa11y packages is v2.0.2 (@sa11y/wdio) going with v3.0.0

