### PR TITLE
build(npm): remove duplicate registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-@types:registry=https://registry.npmjs.org/
 registry=https://registry.npmjs.org/
 save-exact=true


### PR DESCRIPTION
This registry for `@types` scope is the same as the default.