### PR TITLE
feat: remove support for Node.js 12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Before you start, it helps to be familiar with [Web Accessibility](https://trail
 
 ## Requirements
 
--   [Node](https://nodejs.org/) >= 12
+-   [Node](https://nodejs.org/) >= 14
 -   [Yarn](https://yarnpkg.com/) >= 1.22
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
         "webdriverio": "6.12.1"
     },
     "engines": {
-        "node": "^12 || ^14"
+        "node": "^14"
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: `sa11y` will no longer support Node.js 12, which is EOL since 30 April 2022