### PR TITLE
refactor: js config type hints

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,6 @@ module.exports = {
             },
         ],
 
-        'tsdoc/syntax': 'warn',
         'prefer-arrow-callback': 'warn',
     },
     overrides: [
@@ -73,6 +72,12 @@ module.exports = {
             // Enable the Markdown processor for all .md files.
             files: ['**/*.md'],
             processor: 'markdown/markdown',
+        },
+        {
+            files: ['**/*.ts'],
+            rules: {
+                'tsdoc/syntax': 'warn',
+            },
         },
     ],
     env: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/** @type {import('@babel/core').ConfigFunction} */
 module.exports = {
     presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
 };

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+/** @type {import('@commitlint/types').UserConfig} */
 module.exports = {
     extends: ['@commitlint/config-conventional'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,7 @@ const browserLibTestPath = '<rootDir>/packages/browser-lib';
 const integrationTestPath = '<rootDir>/packages/test-integration';
 const wdioTestPath = '<rootDir>/packages/wdio';
 
+/** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
     coverageThreshold: {
         global: {

--- a/packages/test-integration/jest.config.js
+++ b/packages/test-integration/jest.config.js
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+/** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
     setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
     testPathIgnorePatterns: ['__tests__/wdio.test.ts'],

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -12,6 +12,7 @@
 const debug = !!process.env.DEBUG;
 const testPath = '__tests__/**/*.ts';
 
+/** @type { import("webdriverio").Config } */
 exports.config = {
     //
     // ====================


### PR DESCRIPTION
- Only apply eslint rule `tsdoc/syntax` to `**/*.ts`
 
- Add JSDoc type hints to:
  - `babel.config.js`
  - `jest.conf.js`
  - `commitlint.conf.js`
  - `wdio.conf.js`