### PR TITLE
refactor(eslint): don't apply jest rules outside of test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,8 +32,7 @@ module.exports = {
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
         // TODO (spike): Evaluate using https://github.com/standard/eslint-config-standard-with-typescript
         // 'standard-with-typescript',
-        'plugin:jest/recommended',
-        'plugin:jest/style',
+
         'plugin:prettier/recommended',
         'plugin:import/typescript',
         'plugin:import/errors',
@@ -72,6 +71,10 @@ module.exports = {
             // Enable the Markdown processor for all .md files.
             files: ['**/*.md'],
             processor: 'markdown/markdown',
+        },
+        {
+            files: ['**/__tests__/*.[j|t]s'],
+            extends: ['plugin:jest/recommended', 'plugin:jest/style'],
         },
         {
             files: ['**/*.ts'],

--- a/packages/browser-lib/__wdio__/browser-lib.test.ts
+++ b/packages/browser-lib/__wdio__/browser-lib.test.ts
@@ -87,10 +87,7 @@ describe('@sa11y/browser-lib', () => {
         expect(isLoaded('axe')).toBe(false);
     });
 
-    /* eslint-disable jest/expect-expect */
-    it('should inject minified js', () => {
-        verifySa11yLoaded(sa11yMinJS);
-    });
+    it('should inject minified js', () => verifySa11yLoaded(sa11yMinJS));
 
     it('should inject un-minified js', () => {
         verifySa11yLoaded(sa11yJS);
@@ -113,9 +110,5 @@ describe('@sa11y/browser-lib', () => {
         checkNumViolations('', exceptionList, a11yIssuesCountFiltered);
     });
 
-    it('should analyze only specified scope using sa11y', () => {
-        checkNumViolations('div', {}, 1);
-    });
-
-    /* eslint-enable jest/expect-expect */
+    it('should analyze only specified scope using sa11y', () => checkNumViolations('div', {}, 1));
 });

--- a/packages/test-integration/__wdio__/wdio.test.ts
+++ b/packages/test-integration/__wdio__/wdio.test.ts
@@ -20,7 +20,7 @@ const sync: CallableFunction = require('@wdio/sync').default;
 
 // TODO(refactor): Switch to using sa11y API via browser commands for this test module
 describe('integration test @sa11y/wdio in sync mode', () => {
-    /* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, jest/expect-expect */
+    /* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call*/
     it('should throw error for html with a11y issues', () => {
         return sync(() => {
             void browser.url(htmlFileWithA11yIssues);
@@ -41,5 +41,5 @@ describe('integration test @sa11y/wdio in sync mode', () => {
             void checkA11yErrorWdio(assertAccessibleSync, 1);
         });
     });
-    /* eslint-enable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call, jest/expect-expect */
+    /* eslint-enable @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call */
 });

--- a/packages/wdio/__wdio__/wdio.test.ts
+++ b/packages/wdio/__wdio__/wdio.test.ts
@@ -60,7 +60,6 @@ describe('integration test axe with WebdriverIO', () => {
 
 describe('integration test @sa11y/wdio with WebdriverIO', () => {
     // Note: "expect"s are in the helper method "checkAccessible"
-    /* eslint-disable jest/expect-expect */
     it('should not throw error for html with no a11y issues', async () => {
         await browser.url(htmlFileWithNoA11yIssues);
         await checkA11yErrorWdio(assertAccessible);
@@ -80,7 +79,6 @@ describe('integration test @sa11y/wdio with WebdriverIO', () => {
         await browser.url(htmlFileWithA11yIssues);
         await checkA11yErrorWdio(assertAccessible, 1, { scope: browser.$(`#${domWithA11yIssuesBodyID}`) });
     });
-    /* eslint-enable jest/expect-expect */
 
     /* eslint-disable @typescript-eslint/no-unsafe-return,@typescript-eslint/no-unsafe-call */
     it('should not throw error for html with no a11y issues in sync mode', () => {


### PR DESCRIPTION
No need to apply Jest rules to wdio tests or source code.