### PR TITLE
chore(renovate): add 'dependencies' label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,15 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-      "config:base",
-      "helpers:disableTypesNodeMajor",
-      ":automergeLinters",
-      ":automergeRequireAllStatusChecks",
-      ":automergeTesters",
-      ":automergeTypes",
-      ":enableVulnerabilityAlertsWithLabel(security)",
-      ":maintainLockFilesWeekly"
+        "config:base",
+        "helpers:disableTypesNodeMajor",
+        ":automergeLinters",
+        ":automergeRequireAllStatusChecks",
+        ":automergeTesters",
+        ":automergeTypes",
+        ":enableVulnerabilityAlertsWithLabel(security)",
+        ":label(dependencies)",
+        ":maintainLockFilesWeekly"
     ],
     "major": {
         "extends": [":dependencyDashboardApproval"]
@@ -20,8 +21,8 @@
             "extends": [":disableMajorUpdates"]
         },
         {
-          "matchPackageNames": ["axe-core"],
-          "extends": [":dependencyDashboardApproval"]
+            "matchPackageNames": ["axe-core"],
+            "extends": [":dependencyDashboardApproval"]
         },
         {
             "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
Always add the "dependencies" label to Renovate's PRs.