### PR TITLE
build(renovate): renovate config updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,13 @@
         "helpers:disableTypesNodeMajor",
         ":automergeLinters",
         ":automergeRequireAllStatusChecks",
+        ":automergePatch",
         ":automergeTesters",
         ":automergeTypes",
         ":enableVulnerabilityAlertsWithLabel(security)",
         ":label(dependencies)",
-        ":maintainLockFilesWeekly"
+        ":maintainLockFilesWeekly",
+        ":timezone(America/Los_Angeles)"
     ],
     "major": {
         "extends": [":dependencyDashboardApproval"]


### PR DESCRIPTION
- set timezone to Pacific timezone
- auto-merge patch and lockfile updates. See https://docs.renovatebot.com/presets-default/#automergepatch