### PR TITLE
ci(github): skip husky hooks when running in ci env

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "test:watch": "jest --watch",
         "test:auto": "SA11Y_AUTO=1 yarn test --json --outputFile jestResults.json",
         "test:wdio": "wdio run wdio.conf.js --suite wdio --suite integration --suite browserLib < /dev/null",
-        "prepare": "husky install"
+        "prepare": "is-ci || husky install"
     },
     "config": {
         "commitizen": {
@@ -87,6 +87,7 @@
         "eslint-plugin-tsdoc": "0.2.17",
         "eslint-watch": "8.0.0",
         "husky": "8.0.1",
+        "is-ci": "3.0.1",
         "jest": "28.1.3",
         "jest-environment-jsdom": "28.1.3",
         "jest-jasmine2": "28.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7137,6 +7137,13 @@ is-callable@^1.1.4, is-callable@^1.2.7:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
+is-ci@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
+  dependencies:
+    ci-info "^3.2.0"
+
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"


### PR DESCRIPTION
CI doesn't need to comply with husky hooks for commit etc.