### PR TITLE
ci: enable semantic-release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -62,7 +62,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - run: yarn install --frozen-lockfile
-            - run: yarn run semantic-release --dryRun --debug
+            - run: yarn run semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -27,6 +27,4 @@ plugins:
             - 'yarn.lock'
     - '@semantic-release/github'
 
-debug: true
-dryRun: true
 preset: conventionalcommits


### PR DESCRIPTION
Taking the training wheels off and removing the `--dryRun` and `--debug` flags.