### PR TITLE
fix: build before packaging

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -62,6 +62,7 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
 
             - run: yarn install --frozen-lockfile
+            - run: yarn build
             - run: yarn run semantic-release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The releases were not getting `yarn build` before packaging, so the `dist/` folder was empty.

I'd normally call this a `build:` conventional commit, but seeing as the build is quite broken, we'll go with a `fix:`