### PR TITLE
build(semantic-release): remove @semantic-release/git

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -19,12 +19,6 @@ plugins:
       - changelogTitle: "# Changelog\n\nAll notable changes to this project will be documented in this file."
     - - '@semantic-release/exec'
       - publishCmd: yarn lerna publish --no-git-tag-version --no-git-reset --no-push --yes --dist-tag=${nextRelease.channel} --exact ${nextRelease.version}
-    - - '@semantic-release/git'
-      - assets:
-            - 'CHANGELOG.md'
-            - 'package.json'
-            - 'packages/*/package.json'
-            - 'yarn.lock'
     - '@semantic-release/github'
 
 preset: conventionalcommits

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "@commitlint/config-conventional": "17.2.0",
         "@semantic-release/changelog": "6.0.1",
         "@semantic-release/exec": "6.0.3",
-        "@semantic-release/git": "10.0.1",
         "@tsconfig/node14": "1.0.3",
         "@types/jest": "28.1.8",
         "@types/node": "15.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2949,20 +2949,6 @@
     lodash "^4.17.4"
     parse-json "^5.0.0"
 
-"@semantic-release/git@10.0.1":
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-10.0.1.tgz#c646e55d67fae623875bf3a06a634dd434904498"
-  integrity sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==
-  dependencies:
-    "@semantic-release/error" "^3.0.0"
-    aggregate-error "^3.0.0"
-    debug "^4.0.0"
-    dir-glob "^3.0.0"
-    execa "^5.0.0"
-    lodash "^4.17.4"
-    micromatch "^4.0.0"
-    p-reduce "^2.0.0"
-
 "@semantic-release/github@^8.0.0":
   version "8.0.6"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-8.0.6.tgz#5235386d65a5d7d650dc10a6ebce908d213234f7"
@@ -9436,7 +9422,7 @@ micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
     debug "^4.0.0"
     parse-entities "^2.0.0"
 
-micromatch@^4.0.0, micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==


### PR DESCRIPTION
It's not working with the current GitHub branch protections. We'll still get a GitHub Release but without any git commits pushed to the default branch.