### PR TITLE
ci(gha): pin all github action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,11 +20,11 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v2
+              uses: github/codeql-action/init@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
               # Override language selection by uncommenting this and choosing your languages
               with:
                   languages: javascript
@@ -32,7 +32,7 @@ jobs:
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v2
+              uses: github/codeql-action/autobuild@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
 
             # ℹ️ Command-line programs to run using the OS shell.
             # 📚 https://git.io/JvXDl
@@ -46,4 +46,4 @@ jobs:
             #   make release
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v2
+              uses: github/codeql-action/analyze@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,10 +23,10 @@ jobs:
                     - ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: 'yarn'
@@ -35,7 +35,7 @@ jobs:
             - run: yarn build:ci
             - run: yarn test:ci
 
-            - uses: codecov/codecov-action@v3
+            - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
     release:
         name: Release
         needs: lint-build-test # previous job MUST pass to make a release!
@@ -50,12 +50,12 @@ jobs:
             pull-requests: write # to be able to comment on released pull requests
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
               with:
                   fetch-depth: 0 # Need all git history & tags to determine next release version.
                   persist-credentials: false
             - name: Use Node.js 16.x
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
               with:
                   node-version: 16.x
                   cache: 'yarn'


### PR DESCRIPTION
Pinning with the hash. Let's see if Renovate keeps up.

Pins produced with stepSecurity:

https://app.stepsecurity.io/secureworkflow/salesforce/sa11y/codeql-analysis.yml/master?enable=pin https://app.stepsecurity.io/secureworkflow/salesforce/sa11y/nodejs.yml/master?enable=pin