### PR TITLE
chore!: drop nodejs14

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,6 @@ jobs:
         strategy:
             matrix:
                 node-version:
-                    - 14.x
                     - 16.x
                 os:
                     - ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -109,6 +109,6 @@
         "webdriverio": "7.29.1"
     },
     "engines": {
-        "node": "^14 || ^16"
+        "node": "^16"
     }
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "@wdio/local-runner": "7.29.1",
         "@wdio/spec-reporter": "7.29.1",
         "babel-jest": "28.1.3",
-        "chromedriver": "110.0.0",
+        "chromedriver": "113.0.0",
         "commitizen": "4.3.0",
         "conventional-changelog-cli": "2.2.2",
         "cspell": "6.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4800,10 +4800,10 @@ chrome-launcher@^0.15.0:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromedriver@110.0.0:
-  version "110.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-110.0.0.tgz#d00a1a2976592d933faa8e9839e97692922834a4"
-  integrity sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==
+chromedriver@113.0.0:
+  version "113.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-113.0.0.tgz#d4855f156ee51cea4282e04aadd29fa154e44dbb"
+  integrity sha512-UnQlt2kPicYXVNHPzy9HfcWvEbKJjjKAEaatdcnP/lCIRwuSoZFVLH0HVDAGdbraXp3dNVhfE2Qx7gw8TnHnPw==
   dependencies:
     "@testim/chrome-version" "^1.1.3"
     axios "^1.2.1"


### PR DESCRIPTION
Drop Nodejs14 (EOL April 30, 2023) and turn off CI.