### PR TITLE
fix(preset-rules): update a11y config adaptation for resultTypes and reporter

### DIFF
--- a/packages/preset-rules/__tests__/rules.test.ts
+++ b/packages/preset-rules/__tests__/rules.test.ts
@@ -162,8 +162,9 @@ describe('config adapt functions', () => {
     });
 
     it('should customize config as expected for incomplete results', () => {
-        expect(base.reporter).toBe('no-passes');
-        const changedReporter = adaptA11yConfigIncompleteResults(base).reporter;
-        expect(changedReporter).toContain('v2');
+        expect(base.resultTypes[0]).toBe('violations');
+        const changedResultType = adaptA11yConfigIncompleteResults(base).resultTypes[0];
+        console.log('changedResultType', changedResultType);
+        expect(changedResultType).toBe('incomplete');
     });
 });

--- a/packages/preset-rules/src/rules.ts
+++ b/packages/preset-rules/src/rules.ts
@@ -97,7 +97,6 @@ export function adaptA11yConfigCustomRules(config: A11yConfig, customRules: stri
  */
 export function adaptA11yConfigIncompleteResults(config: A11yConfig): A11yConfig {
     const adaptedConfig = JSON.parse(JSON.stringify(config)) as A11yConfig;
-    adaptedConfig.reporter = 'v2';
     adaptedConfig.resultTypes = ['incomplete'];
     return adaptedConfig;
 }
@@ -134,6 +133,6 @@ export function getA11yConfig(rules: RuleInfo): A11yConfig {
         preload: false,
         // Types not listed will still show a maximum of one node
         resultTypes: ['violations'],
-        reporter: 'no-passes', // return only violation results
+        reporter: 'v1', // Use the default reporter to include failureSummary
     };
 }


### PR DESCRIPTION
fix(preset-rules): update a11y config adaptation for resultTypes and reporter

- Change adaptA11yConfigIncompleteResults to set resultTypes to ['incomplete'] and remove reporter override.
- Update getA11yConfig to use reporter 'v1' instead of 'no-passes'.
- Adjust related test to match new config structure.