### PR TITLE
fix(matcher): coalesce mutation observer snapshots per callback batch

### DIFF
--- a/packages/matcher/__tests__/automaticMatcher.test.ts
+++ b/packages/matcher/__tests__/automaticMatcher.test.ts
@@ -24,6 +24,7 @@ import {
     observerOptions,
     defaultAutoCheckOpts,
     defaultRenderedDOMSaveOpts,
+    mutationObserverCallback,
 } from '../src/automatic';
 import * as common from '@sa11y/common';
 import * as assert from '@sa11y/assert';
@@ -301,5 +302,40 @@ describe('runAutomaticCheck runDOMMutationObserver checks', () => {
         document.body.innerHTML = '<div>test</div>';
         await runAutomaticCheck(opts, renderedDOMSaveOpts, '', '');
         expect(writeHtmlSpy).not.toHaveBeenCalled();
+    });
+
+    it('should coalesce all mutation records from a single callback invocation into one snapshot', async () => {
+        // A MutationObserver invokes its callback once per settled batch of synchronous DOM
+        // changes, passing every MutationRecord from that batch. A single re-render (e.g. a
+        // framework inserting several nested nodes) can produce many records in one callback
+        // call. mutationObserverCallback should queue one document.body snapshot per callback
+        // invocation, not one per record, since document.body already reflects the same
+        // settled state for every record in the batch.
+        const getA11yResultsSpy = jest.spyOn(assert, 'getA11yResultsJSDOM').mockResolvedValue([]);
+        document.body.innerHTML = domWithNoA11yIssues;
+        const addedNode = document.body.appendChild(document.createElement('div'));
+
+        // 5 records in one batch, each reporting the same added node, mimics what a single
+        // framework re-render produces: many MutationRecords sharing one settled DOM state.
+        const fakeRecords = Array.from({ length: 5 }, () => ({ addedNodes: [addedNode] } as unknown as MutationRecord));
+        mutationObserverCallback(fakeRecords); // one batch, 5 records -> should queue exactly 1 snapshot
+        mutationObserverCallback(fakeRecords); // a second batch -> should queue exactly 1 more snapshot
+
+        await runAutomaticCheck({ runDOMMutationObserver: true }, {}, 'testPath', 'testName');
+
+        // 1 call for the final DOM state + 1 per queued snapshot (2), not 1 + 10
+        expect(getA11yResultsSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not queue a snapshot when the callback is invoked with no mutation records', async () => {
+        const getA11yResultsSpy = jest.spyOn(assert, 'getA11yResultsJSDOM').mockResolvedValue([]);
+        document.body.innerHTML = domWithNoA11yIssues;
+
+        mutationObserverCallback([]);
+
+        await runAutomaticCheck({ runDOMMutationObserver: true }, {}, 'testPath', 'testName');
+
+        // Only the final DOM state is checked; no replay snapshot was queued
+        expect(getA11yResultsSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/matcher/src/automatic.ts
+++ b/packages/matcher/src/automatic.ts
@@ -183,15 +183,12 @@ export async function runAutomaticCheck(
 }
 
 export function mutationObserverCallback(mutations: MutationRecord[]) {
-    for (const mutation of mutations) {
-        mutation.addedNodes.forEach((node) => {
-            if (node?.parentElement?.innerHTML) {
-                mutatedNodes.push(node.parentElement.innerHTML);
-            } else if ((node as Element)?.outerHTML) {
-                mutatedNodes.push((node as Element).outerHTML);
-            }
-        });
-    }
+    // MutationObserver already batches every synchronous DOM change into a single callback
+    // invocation, so document.body reflects one settled state per call. Capturing it once per
+    // call (instead of once per mutation record's addedNodes) avoids queuing many duplicate or
+    // ancestor-redundant snapshots for a single re-render, each of which would otherwise trigger
+    // its own axe.run() during replay in runAutomaticCheck.
+    if (mutations.length > 0) mutatedNodes.push(document.body.innerHTML);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MutationObserverInit


### PR DESCRIPTION
## Summary

`mutationObserverCallback` in `@sa11y/matcher`'s `automatic.ts` pushes one DOM snapshot onto `mutatedNodes` for every `addedNodes` entry across all `MutationRecord`s in a single callback invocation:

```ts
for (const mutation of mutations) {
    mutation.addedNodes.forEach((node) => {
        if (node?.parentElement?.innerHTML) {
            mutatedNodes.push(node.parentElement.innerHTML);
        } else if ((node as Element)?.outerHTML) {
            mutatedNodes.push((node as Element).outerHTML);
        }
    });
}
```

A `MutationObserver` already batches every synchronous DOM change into a single callback call — `document.body` reflects the exact same settled state for every record in that batch. Looping over `addedNodes` therefore queues many duplicate/ancestor-redundant snapshots for what is really one DOM settle event (e.g. a single framework re-render that inserts several nested nodes).

Each queued snapshot is later replayed through `axe.run()` in `runAutomaticCheck`'s `for await (const mutated of mutatedNodes)` loop, so this duplication multiplies accessibility-check cost. In one of our own test suites (`runDOMMutationObserver: true` enabled), the slowest test file went from **75** `axe.run()` calls down to **4** after this fix, for the same set of childList-addition-driven re-renders.

## Fix

Capture `document.body.innerHTML` once per callback invocation instead of once per added node:

```ts
export function mutationObserverCallback(mutations: MutationRecord[]) {
    if (mutations.length > 0) mutatedNodes.push(document.body.innerHTML);
}
```

## Behavior change beyond deduping — please review carefully

This fix does more than dedupe. Two side effects are worth calling out explicitly, since they affect what gets checked, not just how many times:

1. **Coverage now also includes attribute/characterData/pure-removal mutations.** `observerOptions` (`subtree`, `childList`, `attributes`, `characterData`) has always configured the observer to watch attribute and text mutations, but the *old* callback only ever queued a snapshot when a record's `addedNodes` was non-empty — so attribute-only changes (e.g. `aria-hidden`, `disabled`, class toggles), characterData edits, and pure node removals never triggered a replay check at all. I confirmed this with real `MutationRecord`s captured from an actual observer for each of those three cases: `addedNodes.length === 0` in all of them, and I verified the old callback made 0 pushes for such records. The new callback pushes once per callback invocation regardless of mutation content, so these previously-unchecked mutation types are now checked. This is arguably fixing a second, latent bug (the observer was configured to watch things the callback then ignored), but it does mean consumers relying on `runDOMMutationObserver: true` may see *new* `axe.run()` invocations — and potentially newly-surfaced a11y violations — for DOM changes that were silently skipped before. It is not simply "fewer duplicate checks of the same coverage."
2. **Snapshot content changed from a subtree to the full body.** The old code captured `node.parentElement.innerHTML` (or `node.outerHTML`) — a snippet scoped to the mutated node's ancestor chain — and replayed it by assigning it wholesale to `document.body.innerHTML`. That means the old replay was already checking a partial/lossy view of the DOM (discarding content outside that subtree). The new code captures `document.body.innerHTML` in full, so each replay now checks the entire settled body. This is likely more correct, but it's a second behavior change bundled with the dedup fix.

I don't believe either of these invalidates the fix — if anything, both make the check more correct and more consistent with `observerOptions`'s stated intent — but I want to flag them explicitly rather than characterize this as a pure performance/dedup change with "no change in coverage," since a consuming test suite could see new (valid) failures after upgrading.

## Test plan

- Added two unit tests directly exercising `mutationObserverCallback`:
  - A batch of 5 `MutationRecord`s (all reporting the same added node, mimicking one childList-based re-render) now queues exactly 1 snapshot per callback call instead of 5.
  - An empty batch queues no snapshot.
- Verified the new coalescing test fails against the pre-fix code (11 `axe.run()` calls observed vs. the expected 3), confirming it actually pins the childList-duplication bug rather than trivially passing.
- Manually verified (outside the committed test suite) that real attribute-only/characterData-only/removal-only `MutationRecord`s produce 0 replay pushes under the old callback and 1 push per batch under the new callback, to characterize the coverage-expansion side effect described above.
- `yarn lint` — clean (pre-existing warnings only, unrelated to this change).
- `yarn test` — all 16 suites / 217 tests pass (2 pre-existing skips), no regressions.