### PR TITLE
chore(matcher): instrument MutationObserver path to count tests with mutation nodes @W-23325781

### DIFF
--- a/packages/matcher/src/automatic.ts
+++ b/packages/matcher/src/automatic.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import { AxeResults, log, useCustomRules, writeHtmlFileInPath } from '@sa11y/common';
 import { getA11yResultsJSDOM } from '@sa11y/assert';
+import { AxeResults, log, useCustomRules, writeHtmlFileInPath } from '@sa11y/common';
 import { A11yError, exceptionListFilterSelectorKeywords } from '@sa11y/format';
 import {
-    defaultRuleset,
     adaptA11yConfig,
     adaptA11yConfigCustomRules,
     adaptA11yConfigIncompleteResults,
+    defaultRuleset,
 } from '@sa11y/preset-rules';
 
 /**
@@ -55,6 +55,8 @@ export const defaultRenderedDOMSaveOpts: RenderedDOMSaveOpts = {
 
 let originalDocumentBodyHtml: string | null = null;
 let mutatedNodes: string[] = [];
+
+const moTestsWithMutationNodes: string[] = [];
 
 export const setOriginalDocumentBodyHtml = (bodyHtml: string | null) => {
     originalDocumentBodyHtml = bodyHtml ?? null;
@@ -123,6 +125,18 @@ export async function runAutomaticCheck(
                 currNode = walker.nextSibling();
             }
         } else {
+            // TEMPORARY INSTRUMENTATION (see W-...): mutatedNodes is populated by the observer
+            // before this point and reset in `finally`. Record the name of every test that had
+            // any mutation nodes and log a running count so the autobuild console yields
+            // "<N> tests had mutation nodes" without a cross-worker reporter.
+            if (mutatedNodes.length > 0) {
+                moTestsWithMutationNodes.push(testName);
+            }
+            console.log(
+                `[MutationObserver] aggregate: ${moTestsWithMutationNodes.length} tests had ` +
+                    `mutation nodes (worker-local running total)`
+            );
+
             const a11yResultsJSDOM = await getA11yResultsJSDOM(document.body, config, opts.enableIncompleteResults);
             if (a11yResultsJSDOM?.length > 0) {
                 if (


### PR DESCRIPTION
## What & Why

@W-23325781 — [Jest auto build implementation](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002e2iNjYAI/view)

Adds **temporary instrumentation** to the `runDOMMutationObserver` path in `runAutomaticCheck` to measure how much the DOM MutationObserver is actually helping. A well-behaved Jest test renders close to its final DOM synchronously, so post-render mutations are the signal that a test genuinely depends on the observer.

The instrumentation:
- Records the name of every observer-run test that has post-render mutation nodes (`moTestsWithMutationNodes`).
- Logs a **worker-local running count** so the autobuild console reports how many tests depend on the observer — without needing a cross-worker reporter.

This lets us gather numbers to decide whether the observer path can be removed.

## Note on `console.log`

This uses `console.log` rather than the existing `SA11Y_DEBUG`-gated `log()` helper, so the numbers show up in the autobuild console unconditionally.

I checked with **Navateja**, and we both agreed this is fine for a temporary, testing-only measurement to gather numbers. The alternative — routing through the `SA11Y_DEBUG`-gated logger — would require asking the autobuild team to turn the flag on and then off again, which adds turnaround time. Since this is throwaway instrumentation, `console.log` is the pragmatic choice.

The block is clearly marked `TEMPORARY INSTRUMENTATION` and is to be **removed** once the keep/remove decision on the observer path is made.

## Testing

- `jest packages/matcher/__tests__/automaticMatcher.test.ts` — all tests pass.