### PR TITLE
fix(ci): unblock Release job on Node 22 with pinned npm@12

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -60,16 +60,18 @@ jobs:
               with:
                   fetch-depth: 0 # Need all git history & tags to determine next release version.
                   persist-credentials: false
-            - name: Use Node.js 20.x
+            - name: Use Node.js 22.x
               uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
-                  node-version: 20.x
+                  node-version: 22.x
                   cache: 'yarn'
                   registry-url: 'https://registry.npmjs.org'
 
-            # Upgrade npm to latest for OIDC support
+            # Upgrade npm for OIDC trusted publishing support (requires npm >= 11.5.1).
+            # Pin to npm@12 rather than npm@latest: a floating latest broke this job when
+            # npm@12 dropped Node 20 (EBADENGINE). npm@12 supports OIDC and runs on Node 22 & 24.
             - name: Upgrade npm
-              run: npm install -g npm@latest
+              run: npm install -g npm@12
 
             - run: yarn install --frozen-lockfile
             - run: yarn build


### PR DESCRIPTION
## Problem

The **Release** job in `.github/workflows/nodejs.yml` has been failing on every push to `master`. The current failure (run [30430847182](https://github.com/salesforce/sa11y/actions/runs/30430847182)) dies at the **Upgrade npm** step:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

**Root cause:** the job pins **Node 20.x** and runs `npm install -g npm@latest`. `npm@12` (published 2026-07-08) dropped Node 20 support, so a floating `latest` now errors on Node 20. This breaks releases for *any* commit, not a specific change.

## Fix

- Bump the Release job to **Node 22.x** (active LTS; resolves to v22.23.1, which satisfies npm@12's `^22.22.2` engine).
- Pin **`npm@12`** instead of `npm@latest`. npm@12 supports OIDC trusted publishing (needs npm ≥ 11.5.1) and runs on both Node 22 and Node 24, so this is stable against future npm majors.

The three test-matrix jobs (Node 20/22/24) already pass; only the Release job is affected. The `lint-build-test` matrix is intentionally left unchanged.

## Testing done locally

| Check | Result |
|---|---|
| `tsc --build` (baseline) | ✅ exit 0 |
| Ran the exact `lerna version 8.0.28 --exact` from `.releaserc.yml` | ✅ all 11 packages + inter-`@sa11y` deps bumped in lockstep, 0 stale refs |
| `tsc --build` after version bump | ✅ exit 0 (full clean rebuild) |
| `jest packages/matcher` after bump | ✅ 37/37 pass |
| Node 22.x vs npm@12 engine | ✅ v22.23.1 satisfies `^22.22.2` |
| `@semantic-release/commit-analyzer` on current commits | confirms `feat`→minor / `fix`→patch behavior |
| YAML syntax | ✅ valid |

## Release implication

This commit is typed `fix(ci)`, so on merge semantic-release will cut a **patch (v8.0.28)** and publish. That release will also include the already-merged MutationObserver instrumentation (`ca28e5a`), which is a `chore` and would not have triggered a release on its own.

> **Note for maintainers:** the Release job also failed earlier (early June, at the `Run semantic-release` step, before npm@12 existed). Those logs are purged, so the live `npm publish --provenance` / OIDC step could not be exercised locally. Worth watching the first release run after this merges. v8.0.27 *was* published with SLSA provenance in January, so the OIDC config was valid then.
