### PR TITLE
fix(release): drop @semantic-release/git plugin

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -19,13 +19,6 @@ plugins:
       - changelogTitle: "# Changelog\n\nAll notable changes to this project will be documented in this file."
     - - '@semantic-release/exec'
       - publishCmd: yarn lerna version ${nextRelease.version} --no-git-tag-version --no-push --yes --exact && echo "true" > .release-created
-    - - '@semantic-release/git'
-      - assets:
-            - 'package.json'
-            - 'lerna.json'
-            - 'CHANGELOG.md'
-            - 'packages/*/package.json'
-        message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}'
     - '@semantic-release/github'
 
 preset: conventionalcommits


### PR DESCRIPTION
## Problem

With the Node/npm fix from #995 merged, the Release job now runs far enough to reach `semantic-release`, but it fails at **GH006: Protected branch update failed**.

Root cause: the `@semantic-release/git` plugin tries to commit the version bump back to `master` via `git push HEAD:master`. `master` is protected, and the CI `GITHUB_TOKEN` cannot push to it, so the release aborts.

## History

This plugin was **not** part of the pipeline from `4.0.0` through `8.0.26`. It was added in **#931** (dc4d10b). The failure stayed latent because the earlier npm EBADENGINE crash killed the job before it ever reached the push step — #995 fixed that crash, which is why the GH006 failure only surfaced now.

## Fix

Remove the `@semantic-release/git` plugin, restoring the proven pre-#931 configuration that published every release through v8.0.27.

No manual version bump is needed: semantic-release derives the next version from **git tags**, not from `master`'s `package.json`. The `@semantic-release/exec` step still runs `lerna version <next> --exact` in CI to pin exact versions before `npm publish --provenance`.

This commit uses a `fix(release):` type so the merge itself triggers the next patch release (8.0.28), which carries the MutationObserver instrumentation to npm.

## Scope

Single file: `.releaserc.yml` (removes the 7-line git-plugin block).